### PR TITLE
Revert "port statusbar brightness slider from ROM control"

### DIFF
--- a/res/values/bs_strings.xml
+++ b/res/values/bs_strings.xml
@@ -1441,7 +1441,6 @@
     <string name="notification_color">Notification background color</string>
 
     <string name="notifications_on_lockscreen">Notifications on lockscreen</string>
-    <string name="notifications_on_lockscreen_summary">Choose between manners to show pending notifications on lockscreen</string>
     <string name="notifications_on_lockscreen_warning_summary">Each one of notifications on lockscreen services under (PEEK and LOCKSCREEN NOTIFICATIONS) will auto disable the other. the sensors status below should be green, PEEK or LOCKSCREEN NOTIFICATIONS uses two sensors in particular, the gyroscope or the proximity sensor.</string>
 
     <!--Notification peek-->

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -698,12 +698,6 @@
     <!-- GPS download data over wi-fi only -->
     <string name="gps_download_data_wifi_only">Download GPS assisted data only over Wi-Fi networks</string>
 
-    <!-- Status bar brightness slider -->
-    <string name="brightness_slider_title">Statusbar brightness slider</string>
-    <string name="brightness_slider_summary">When enabled, this option will allow you to change the brightness by
-        sliding your finger across the Statusbar. Note: Will not be active when auto-brightness is on
-    </string>
-
     <!-- USB Mass Storage -->
     <string name="usb_mass_storage_title">Mass storage (UMS)</string>
     <string name="usb_mass_storage_summary">Lets you transfer any files between your computer and your SD card by mounting it as a flash device</string>

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -22,12 +22,6 @@
                 android:title="@string/brightness"
                 android:persistent="false"/>
 
-	<CheckBoxPreference
-            android:key="statusbar_brightness_slider"
-            android:title="@string/brightness_slider_title"
-            android:summary="@string/brightness_slider_summary"
-            android:defaultValue="false" />
-
         <PreferenceScreen
             android:persistent="false"
             android:key="screencolor_settings"

--- a/res/xml/lockscreen_interface_settings.xml
+++ b/res/xml/lockscreen_interface_settings.xml
@@ -68,11 +68,6 @@
             android:title="@string/lockscreen_buttons_title"
             android:summary="@string/lockscreen_buttons_summary" />
 
-        <PreferenceScreen
-            android:title="@string/notifications_on_lockscreen"
-            android:fragment="com.android.settings.beanstalk.LockscreenNotifications"
-            android:summary="@string/notifications_on_lockscreen_summary" />
-
     <PreferenceCategory
         android:title="@string/lockscreen_widgets_title"
         android:key="keyguard_enable_widgets" >

--- a/src/com/android/settings/DisplaySettings.java
+++ b/src/com/android/settings/DisplaySettings.java
@@ -74,7 +74,6 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
     private static final String KEY_NOTIFICATION_PULSE = "notification_pulse";
     private static final String KEY_BATTERY_LIGHT = "battery_light";
     private static final String KEY_WAKE_WHEN_PLUGGED_OR_UNPLUGGED = "wake_when_plugged_or_unplugged";
-    private static final String STATUS_BAR_BRIGHTNESS = "statusbar_brightness_slider";
     private static final String KEY_SCREEN_COLOR_SETTINGS = "screencolor_settings";
 
     private static final int DLG_GLOBAL_CHANGE_WARNING = 1;
@@ -82,7 +81,6 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
     private CheckBoxPreference mAccelerometer;
     private FontDialogPreference mFontSizePref;
     private CheckBoxPreference mWakeWhenPluggedOrUnplugged;
-    private CheckBoxPreference mStatusbarSliderPreference;
 
     private PreferenceScreen mNotificationPulse;
     private PreferenceScreen mBatteryPulse;
@@ -142,10 +140,6 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
         mFontSizePref = (FontDialogPreference) findPreference(KEY_FONT_SIZE);
         mFontSizePref.setOnPreferenceChangeListener(this);
         mFontSizePref.setOnPreferenceClickListener(this);
-
-	mStatusbarSliderPreference = (CheckBoxPreference) findPreference(STATUS_BAR_BRIGHTNESS);
-        mStatusbarSliderPreference.setChecked((Settings.System.getInt(getActivity().getApplicationContext().getContentResolver(),
-                Settings.System.STATUSBAR_BRIGHTNESS_SLIDER, 0) == 1));
 
         mAdaptiveBacklight = (CheckBoxPreference) findPreference(KEY_ADAPTIVE_BACKLIGHT);
         if (!isAdaptiveBacklightSupported()) {
@@ -439,10 +433,6 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
             Settings.Global.putInt(getContentResolver(),
                     Settings.Global.WAKE_WHEN_PLUGGED_OR_UNPLUGGED,
                     mWakeWhenPluggedOrUnplugged.isChecked() ? 1 : 0);
-            return true;
-	} else if (preference == mStatusbarSliderPreference) {
-            Settings.System.putInt(getActivity().getApplicationContext().getContentResolver(),
-                    Settings.System.STATUSBAR_BRIGHTNESS_SLIDER, mStatusbarSliderPreference.isChecked() ? 1 : 0);
             return true;
         } else if (preference == mTapToWake) {
             return TapToWake.setEnabled(mTapToWake.isChecked());


### PR DESCRIPTION
Removed Slider brightness option, because there is an option like this too in Settings/BeanStalk options/Status bar/
